### PR TITLE
Importer: comment out unfinished code.

### DIFF
--- a/ahjodoc/geo.py
+++ b/ahjodoc/geo.py
@@ -97,18 +97,20 @@ class AhjoGeocoder(object):
             unit_id = int(unit_id)
             district_id = block_id // 1000
             block_id %= 1000
-            if rest:
-                if rest[0].lower() in ('a', 'b', 'c', 'd', 'e'):
-                    rest = rest[1:]
-                rest = rest.strip()
-                if rest and rest[0] == '-':
-                    range_end = int(re.match('-\s?(\d)+', rest).groups()[0])
-                elif rest.startswith('ja'):
-                    range_end = int(rest[2:])
-                elif rest.lower().startswith('.a'): # Ksv notation
-                    pass
-                elif rest.startswith(':'): # ???
-                    pass
+            # TODO: Code the logic to extract and use unit
+            #       ids from the rest of the match.
+            # if rest:
+            #     if rest[0].lower() in ('a', 'b', 'c', 'd', 'e'):
+            #         rest = rest[1:]
+            #     rest = rest.strip()
+            #     if rest and rest[0] == '-':
+            #         range_end = int(re.match('-\s?(\d)+', rest).groups()[0])
+            #     elif rest.startswith('ja'):
+            #         range_end = int(rest[2:])
+            #     elif rest.lower().startswith('.a'): # Ksv notation
+            #         pass
+            #     elif rest.startswith(':'): # ???
+            #         pass
             # check for '161/3.A' style
             if not district_id:
                 for l in context['all_text']:


### PR DESCRIPTION
The commented code caused the import to fail without
serving any real purpose. Currently the geo extraction
only considers the first unit number, and the rest should
be read as well in the future.
